### PR TITLE
fixed parameter handling in Sandbox for get requests

### DIFF
--- a/Resources/views/template/index.html
+++ b/Resources/views/template/index.html
@@ -135,8 +135,15 @@
         $('body').on('click', '.send', function(e) {
             e.preventDefault();
             var form = $(this).closest('form');
-            var matchedParamsInRoute = $(form).attr('action').match(/{\w+}$/);
+            //added /g to get all the matched params instead of only first
+            var matchedParamsInRoute = $(form).attr('action').match(/{\w+}/g);
             var theId = $(this).attr('rel');
+            //keep a copy of action attribute in order to modify the copy 
+            //instead of the initial attribute
+            var url = $(form).attr('action');
+            
+            //get form serialized data in order to remove matchedParams
+            var serializedData = $(form).serialize().replace(/&?[^=&]+=(&|$)/g,'');
             if (matchedParamsInRoute) {
                 $("form#" + $(form).attr('id') + " input[type=text]").each(function() {
                     var input = $(this);
@@ -145,8 +152,19 @@
                         try {
                             var tmp = matchedParamsInRoute[index].replace('{', '').replace('}', '');
                             if ($(this).attr('id') == tmp) {
-                                var newFormAction = $(form).attr('action').replace(matchedParamsInRoute[index], $(this).val());
-                                $(form).attr('action', newFormAction);
+                                //if the param is not set remove it from url
+                                if(!$(this).val().length){
+                                    url = url.replace(matchedParamsInRoute[index], "");
+                                    url = url.replace(tmp + "/", "");
+                                } else {
+                                    url = url.replace(matchedParamsInRoute[index], $(this).val());
+                                }
+                                //remove from serialized data
+                                var replaceString =  tmp + "\=([^&]+[&]?)|&(" + tmp + ")\=([^&]+)";
+                                var match = serializedData.match(replaceString);
+                                if(match.length > 0){
+                                    serializedData = serializedData.replace(match[0],'');
+                                }
                             }
                         } catch (err) {
                             console.log(err);
@@ -154,6 +172,7 @@
                     }
                 });
             };
+
             var st_headers = {};
             
             apiKey = $('#apikey_key').val();
@@ -172,9 +191,8 @@
 
             console.log(st_headers);
 
-            serializedData = $(form).serialize().replace(/&?[^=&]+=(&|$)/g,'');
             $.ajax({
-                url: $('#apiUrl').val() + $(form).attr('action'),
+                url: $('#apiUrl').val() + url,
                 data: serializedData,
                 type: '' + $(form).attr('method') + '',
                 dataType: 'json',


### PR DESCRIPTION
First of all Thank you for the great work in this project!

I have made some modifications to enhance the sandbox functionality, feel free to use any of them if you find them useful.

The changes i made are focused in GET requests with restful-like parameters
(ie.`http://example.com/api/get_pets/type/{type}/limit/{limit}/offset/{offset}` )

The issues addressed are:
1) changed regex for matchedParamsInRoute from `/{\w+}$/` to `/{\w+}/g` in order to match all params not only the first
2) created a new variable that keeps the modified url to avoid changing form's action attribute 
3) removed matchedParamsInRoute matches from the serialized string to avoid sending them twice in the request
4) removed from the url variable any parameters for which the corresponding input field was empty 
