### PR TITLE
Group endpoints in the same section properly

### DIFF
--- a/Builder.php
+++ b/Builder.php
@@ -134,7 +134,8 @@ class Builder
         $output = '';
 
         foreach ($template as $key => $value) {
-          $output .= implode(PHP_EOL,  array_merge(['<h2>' . $key . '</h2>'], $value));
+          array_unshift($value, '<h2>' . $key . '</h2>');
+          $output .= implode(PHP_EOL, $value);
         }
 
         $this->saveTemplate($output, $this->_output_file);


### PR DESCRIPTION
Allow for endpoints in different files to belong to the same section (and show them grouped properly) as long as they have the same 'section' inside @ApiDescription.
