### PR TITLE
Fixed insecure script errors and options being undefined

### DIFF
--- a/Builder.php
+++ b/Builder.php
@@ -329,7 +329,8 @@ class Builder
             'POST'   => 'label-primary',
             'GET'    => 'label-success',
             'PUT'    => 'label-warning',
-            'DELETE' => 'label-danger'
+            'DELETE' => 'label-danger',
+            'OPTIONS'=> 'label-info'
         );
 
         return '<span class="label '.$st_labels[$method].'">'.$method.'</span>';

--- a/Resources/views/template/index.html
+++ b/Resources/views/template/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="php-apidoc - apid documenation generator">
     <meta name="author" content="Calin Rada">
     <title>{{ title }}</title>
-    <link href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet">
     <style type="text/css">
         body      { padding-top: 70px; margin-bottom: 15px; }
         .tab-pane { padding-top: 10px; }
@@ -76,7 +76,7 @@
     </div> <!-- /container -->
 
     <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
     <script type="text/javascript">
     function syntaxHighlight(json) {
         if (typeof json != 'string') {


### PR DESCRIPTION
Chrome and Firefox send insecure content warnings when viewing from https, and options was throwing errors when creating the page so I assigned it a label
