### PR TITLE
Fix in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $output_dir  = __DIR__.'/apidocs';
 $output_file = 'api.html'; // defaults to index.html
 
 try {
-    $builder = new Builder($classes, $output_dir, $output_file);
+    $builder = new Builder($classes, $output_dir, 'Api Title', $output_file);
     $builder->generate();
 } catch (Exception $e) {
     echo 'There was an error generating the documentation: ', $e->getMessage();


### PR DESCRIPTION
Accord with the  Builder's construct signature:

    public function __construct(array $st_classes, $s_output_dir, $title = 'php-apidoc', $s_output_file = 'index.html', $template_path = null)
     {
    ...
    }

The output_file param is the four one and in the readme.md file it is the third one, this PR fix this problem.