### PR TITLE
Fix a javascript error when the sample values aren't JSON.

### DIFF
--- a/Builder.php
+++ b/Builder.php
@@ -500,7 +500,7 @@ static $samplePostBodyTpl = '<pre id="sample_post_body{{ elt_id }}">{{ body }}</
 </tr>';
 
         static $paramSampleBtnTpl = '
-<a href="javascript:void(0);" data-toggle="popover" data-placement="bottom" title="Sample" data-content="{{ sample }}">
+<a href="javascript:void(0);" data-toggle="popover" data-trigger="focus" data-placement="bottom" title="Sample" data-content="{{ sample }}">
     <i class="btn glyphicon glyphicon-exclamation-sign"></i>
 </a>';
 

--- a/Resources/views/template/index.html
+++ b/Resources/views/template/index.html
@@ -114,6 +114,13 @@
         });
     }
 
+    function prepareStr(str) {
+        try {
+            return syntaxHighlight(JSON.stringify(JSON.parse(str.replace(/'/g, '"')), null, 2));
+        } catch (e) {
+            return str;
+        }
+    }
     var storage = (function() {
         var uid = new Date;
         var storage;
@@ -170,19 +177,20 @@
             if ($(this).html() == 'NA') {
                 return;
             }
-            var str = JSON.stringify(JSON.parse($(this).html().replace(/'/g, '"')), undefined, 2);
-            $(this).html(syntaxHighlight(str));
+            var str = prepareStr($(this).html());
+            $(this).html(str);
         });
 
         $("[data-toggle=popover]").popover({placement:'right'});
 
-        $('body').on('shown.bs.popover', function() {
-            var $sample = $(this).find(".popover-content");
-            if ($sample.html() == 'NA') {
+        $('[data-toggle=popover]').on('shown.bs.popover', function() {
+            var $sample = $(this).parent().find(".popover-content"),
+                str = $(this).data('content');
+            if (typeof str == "undefined" || str === "") {
                 return;
             }
-            var str = JSON.stringify(JSON.parse($sample.html().replace(/'/g, '"')), undefined, 2);
-            $sample.html('<pre>' + syntaxHighlight(str) + '</pre>');
+            var str = prepareStr(str);
+            $sample.html('<pre>' + str + '</pre>');
         });
 
         $('body').on('click', '#save_auth_data', function(e) {


### PR DESCRIPTION
What this PR does is:

-  Add the  data-trigger="focus" in the popovers, this helps to remove avoid have multiple popovers at the same time and let the user close the active popover just clicking elsewhere.

- The  ApiParams sample value expects a JSON value but not all the APIs sent JSON format, so now the sample param can contain a  non-json string.  (before this PR a non-json value trigger a JS error)